### PR TITLE
fix(configs): disable `override logger` in the `trainer/evaluation` config

### DIFF
--- a/configs/trainer/evaluation.yaml
+++ b/configs/trainer/evaluation.yaml
@@ -3,7 +3,7 @@ defaults:
   - override callbacks:
       - model_summary
       - rich_progress
-  - override logger: wandb_evaluation
+  # - override logger: wandb_evaluation
   - _self_
 
 max_epochs: 1


### PR DESCRIPTION
for this, because I had already disabled the `logger` package in trainer/default.yaml, this was erroring.

by default, this'll mean no logging to wandb/hf/whatever, which is fine for this. If you need it, then you can enable it and do what you gotta do. 

Closes #7 